### PR TITLE
Fix compatibility with newer Node versions

### DIFF
--- a/CashflowClient/package.json
+++ b/CashflowClient/package.json
@@ -19,5 +19,12 @@
     "jquery": "^3.1.1",
     "md5-js": "0.0.3",
     "phaser": "^2.6.2"
+  },
+  "scripts": {
+    // Your current package.json scripts
+    "preinstall": "npx npm-force-resolutions"
+  },
+  "resolutions": {
+    "graceful-fs": "^4.2.4"
   }
 }

--- a/CashflowClient/package.json
+++ b/CashflowClient/package.json
@@ -21,7 +21,6 @@
     "phaser": "^2.6.2"
   },
   "scripts": {
-    // Your current package.json scripts
     "preinstall": "npx npm-force-resolutions"
   },
   "resolutions": {


### PR DESCRIPTION
This fixes running `gulp` for the Cashflow client - the why is found here: https://stackoverflow.com/a/58394828/221612